### PR TITLE
Fix close() method for non-image data

### DIFF
--- a/renishawWiRE/wdfReader.py
+++ b/renishawWiRE/wdfReader.py
@@ -124,7 +124,8 @@ class WDFReader(object):
 
     def close(self):
         self.file_obj.close()
-        self.img.close()
+        if hasattr(self, "img"):
+            self.img.close()
 
     def __get_type_string(self, attr, data_type):
         """Get the enumerated-data_type as string


### PR DESCRIPTION
The close() method threw an error if self.img did not exist; and it did not for data without images.