### PR TITLE
conda/meta.yaml for building conda packages

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,34 @@
+{% set data = load_setup_py_data() %}
+{% set version = data['version'] %}
+
+package:
+  name: renishawwire
+  version: {{ data['version'] }}
+
+source:
+  git_url: ../
+
+build:
+  number: 0
+  noarch: python
+  script:
+    - python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy >=1.12.0
+
+test:
+  imports:
+    - renishawWiRE
+
+about:
+  home: https://github.com/alchem0x2A/py-wdf-reader
+  license: GPL-3
+  license_family: GPL
+  summary: 'Reading wdf Raman spectroscopy file from Renishaw WiRE'
+


### PR DESCRIPTION
Conda packages can be built with "conda-build conda/" (a package I got with that command is on https://quasar.codes/conda/noarch/).

I need conda packages for all requirements to create Windows installers for Quasar (https://quasar.codes). Adding this code to your repo makes building them easier, because all the code is already in the repo. But anyway, feel free to close this PR if you do not want this inside your repository.

Ideally, this package should become a part of the conda-forge, which then takes care of building packages.