### PR TITLE
Include license in sdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 # Inside of setup.cfg
 [metadata]
 description-file = README.md
+license_file = LICENSE


### PR DESCRIPTION
I would like to get `renishawWiRE` packaged on conda-forge and I can help since I am familiar with the conda-forge infrastructure.
One recommended practise for conda-forge packaging is to include the `LICENSE` file in the source distribution available on pypi and then used by conda-forge, therefore this PR.

In order to make the package on conda-forge, I would suggest the following:
1. merge this PR
2. once a release including this change is available on pypi, make a PR to https://github.com/conda-forge/staged-recipes - see https://conda-forge.org/docs/maintainer/adding_pkgs.html

Since this a pure python package, building the recipe will be very simple, only a couple of changes are required from https://github.com/alchem0x2A/py-wdf-reader/blob/master/conda/meta.yaml
I can easily do 2 and keep you (@alchem0x2A) in the loop and add you as recipe maintainer on conda-forge, so that you can follow what is going on with the conda-forge package.

@alchem0x2A, what do you think?