### PR TITLE
Timestamp update

### DIFF
--- a/renishawWiRE/types.py
+++ b/renishawWiRE/types.py
@@ -100,7 +100,8 @@ class UnitType(IntEnum):
                         Celsius="°C",
                         Fahrenheit="°F",
                         KelvinPerMinute="K/min",
-                        FileTime="",)
+                        FileTime="s",  # FileTime use stamps and in relative second
+                       )
         return unit_str[self._name_]
 
 

--- a/renishawWiRE/wdfReader.py
+++ b/renishawWiRE/wdfReader.py
@@ -328,8 +328,18 @@ class WDFReader(object):
             self.origin_list_header[i][3] = s
             # Last: the actual data
             # array = numpy.empty(self.count)
-            array = numpy.array([self.__read_type("double")
+            
+            # Time appears to be recorded as int64 in 100 nanosecond intervals
+            # Reference does not appear to be  Unix Epoch time  
+            # Set time[0] = 0 until timestamp reference can be determined
+            if self.origin_list_header[i][1] == DataType.Time:             
+                array = numpy.array([self.__read_type("int64")
+                                 for i in range(self.count)]) / 1e7
+                array = array - array[0]
+            else: 
+                array = numpy.array([self.__read_type("double")
                                  for i in range(self.count)])
+                
             self.origin_list_header[i][4] = array
             # Set self.xpos or self.ypos
             if self.origin_list_header[i][1] == DataType.Spatial_X:

--- a/renishawWiRE/wdfReader.py
+++ b/renishawWiRE/wdfReader.py
@@ -330,8 +330,10 @@ class WDFReader(object):
             # array = numpy.empty(self.count)
             
             # Time appears to be recorded as int64 in 100 nanosecond intervals
+            # Possibly using the .NET DateTime epoch
             # Reference does not appear to be  Unix Epoch time  
             # Set time[0] = 0 until timestamp reference can be determined
+            # Resulting array will have unit of `FileTime` in seconds
             if self.origin_list_header[i][1] == DataType.Time:             
                 array = numpy.array([self.__read_type("int64")
                                  for i in range(self.count)]) / 1e7


### PR DESCRIPTION
The Time parameter in the origin_list_header is an int64 in 100ns intervals. I've confirmed this by comparison with numerous "series" measurements within WiRE. I can't tell the reference time being used, so it was temporarily set in time relative to the first measurement